### PR TITLE
remove override from plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,6 @@
                                 <revealjsdir>reveal.js-${revealjs.version}</revealjsdir>
                                 <!-- put here the reveal.js specific attributes -->
                                 <sourcedir>${basedir}/src/main/java</sourcedir>
-                                <revealjs_theme>black</revealjs_theme>
                                 <revealjs_transition>linear</revealjs_transition>
                                 <project-version>${project.version}</project-version>
                                 <!-- can use any pygments/rouge css here -->


### PR DESCRIPTION
if the variables are overridden in the maven plugin, they appear to override what you have in the adoc. 